### PR TITLE
CFY-7279 Add create operation

### DIFF
--- a/aria_plugin/constants.py
+++ b/aria_plugin/constants.py
@@ -1,0 +1,26 @@
+########
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+CSAR_PATH_PROPERTY = 'csar_path'
+PLUGINS_PROPERTY = 'plugins'
+INPUTS_PROPERTY = 'inputs'
+
+ARIA_PLUGINS_DIR = 'plugins'
+ARIA_MODELS_DIR = 'models'
+ARIA_RESOURCES_DIR = 'resources'
+
+WAGON_EXTENSION = '.wgn'
+
+SERVICE_TEMPLATE_NAME_FORMAT = '{tenant}-{dep_id}'

--- a/aria_plugin/environment.py
+++ b/aria_plugin/environment.py
@@ -1,0 +1,116 @@
+########
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+import errno
+import os
+
+import aria
+from aria.core import Core
+from aria.orchestrator.plugin import PluginManager
+from aria.storage.sql_mapi import SQLAlchemyModelAPI
+from aria.storage.filesystem_rapi import FileSystemResourceAPI
+from cloudify import ctx
+
+
+class Environment(object):
+
+    MANAGER_RESOURCES_DIR = '/opt/manager/resources'
+    BLUEPRINTS_DIR = os.path.join(MANAGER_RESOURCES_DIR, 'blueprints')
+    CLOUDIFY_PLUGINS_DIR = os.path.join(MANAGER_RESOURCES_DIR, 'plugins')
+
+    def __init__(self):
+
+        self._mk_working_dir()
+
+        self._to_clean = []
+
+        # Initialized lazily:
+        self._model_storage = None
+        self._resource_storage = None
+        self._plugin_manager = None
+        self._core = None
+
+    @property
+    def workdir(self):
+        return self._workdir
+
+    @property
+    def blueprint_dir(self):
+        return os.path.join(self.BLUEPRINTS_DIR,
+                            ctx.tenant_name,
+                            ctx.blueprint.id)
+
+    @property
+    def model_storage(self):
+        if not self._model_storage:
+            initiator_kwargs = {'base_dir': self.model_storage_dir}
+            self._model_storage = aria.application_model_storage(
+                api=SQLAlchemyModelAPI, initiator_kwargs=initiator_kwargs)
+        return self._model_storage
+
+    @property
+    def resource_storage(self):
+        if not self._resource_storage:
+            api_kwargs = {'directory': self.resource_storage_dir}
+            self._resource_storage = aria.application_resource_storage(
+                api=FileSystemResourceAPI, api_kwargs=api_kwargs)
+        return self._resource_storage
+
+    @property
+    def plugin_manager(self):
+        if not self._plugin_manager:
+            self._plugin_manager = PluginManager(
+                model=self.model_storage, plugins_dir=self.aria_plugins_dir)
+        return self._plugin_manager
+
+    @property
+    def core(self):
+        if not self._core:
+            self._core = Core(model_storage=self.model_storage,
+                              resource_storage=self.resource_storage,
+                              plugin_manager=self.plugin_manager)
+        return self._core
+
+    @property
+    def aria_plugins_dir(self):
+        return os.path.join(self.workdir, 'plugins')
+
+    @property
+    def model_storage_dir(self):
+        return os.path.join(self.workdir, 'models')
+
+    @property
+    def resource_storage_dir(self):
+        return os.path.join(self.workdir, 'resources')
+
+    def _mk_working_dir(self):
+        dir_name = 'aria-{tenant_name}'.format(tenant_name=ctx.tenant_name)
+        abs_path = os.path.join(self.CLOUDIFY_PLUGINS_DIR, dir_name)
+
+        self._workdir = _create_if_not_existing(abs_path)
+
+        # create subdirectories
+        _create_if_not_existing(self.aria_plugins_dir)
+        _create_if_not_existing(self.model_storage_dir)
+        _create_if_not_existing(self.resource_storage_dir)
+
+
+def _create_if_not_existing(path):
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+    return path

--- a/aria_plugin/exceptions.py
+++ b/aria_plugin/exceptions.py
@@ -1,0 +1,20 @@
+########
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+from cloudify.exceptions import NonRecoverableError
+
+
+class MissingPluginsException(NonRecoverableError):
+    pass

--- a/aria_plugin/operations.py
+++ b/aria_plugin/operations.py
@@ -1,0 +1,69 @@
+########
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+import os
+
+import aria
+from cloudify import ctx
+from cloudify.decorators import operation
+
+from .constants import (CSAR_PATH_PROPERTY, INPUTS_PROPERTY, PLUGINS_PROPERTY,
+                        SERVICE_TEMPLATE_NAME_FORMAT)
+
+from .environment import Environment
+from .utils import (generate_csar_source, extract_csar, install_plugins,
+                    log_unused_plugins, store_service_template, create_service,
+                    cleanup_files)
+
+
+@operation
+def create():
+    env = Environment()
+
+    # extract csar
+    csar_path = ctx.node.properties[CSAR_PATH_PROPERTY]
+    csar_source = generate_csar_source(csar_path, env.blueprint_dir)
+    csar = extract_csar(csar_source, ctx.logger)
+    files_to_remove = [csar.destination]
+    csar_plugins_dir = os.path.join(csar.destination, 'plugins')
+
+    # install plugins
+    plugins_to_install = ctx.node.properties[PLUGINS_PROPERTY]
+    ctx.logger.info('Installing required plugins for ARIA: {0}...'
+                    .format(plugins_to_install))
+    install_plugins(csar_plugins_dir, plugins_to_install, env.plugin_manager)
+    ctx.logger.info('Successfully installed required plugins')
+    log_unused_plugins(ctx.logger, csar_plugins_dir, plugins_to_install)
+
+    # store service template
+    aria.install_aria_extensions()
+    service_template_path = os.path.join(csar.destination,
+                                         csar.entry_definitions)
+    service_template_name = SERVICE_TEMPLATE_NAME_FORMAT.format(
+        tenant=ctx.tenant_name, dep_id=ctx.deployment.id)
+    ctx.logger.info('Storing service template {0}...'
+                    .format(service_template_name))
+    store_service_template(env.core, service_template_path,
+                           service_template_name)
+    ctx.logger.info('Successfully stored service template')
+
+    # create service
+    inputs = ctx.node.properties[INPUTS_PROPERTY]
+    ctx.logger.info('Creating service {0} with inputs {1}...'
+                    .format(service_template_name, inputs))
+    create_service(env.core, service_template_name, inputs)
+    ctx.logger.info('Successfully created service')
+
+    cleanup_files(files_to_remove)

--- a/aria_plugin/utils.py
+++ b/aria_plugin/utils.py
@@ -1,0 +1,100 @@
+########
+# Copyright (c) 2017 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+import errno
+import os
+import shutil
+import tempfile
+
+
+from aria.cli import csar
+
+from .constants import WAGON_EXTENSION
+from .exceptions import MissingPluginsException
+
+
+def extract_csar(csar_source, logger):
+    csar_dest = tempfile.mkdtemp(prefix='tmp-csar-')
+    return csar.read(source=csar_source, destination=csar_dest, logger=logger)
+
+
+def generate_csar_source(csar_path, blueprint_dir):
+    if '://' not in csar_path:
+        # the csar_path property is relative to the blueprint's directory
+        csar_path = os.path.join(blueprint_dir, csar_path)
+    return csar_path
+
+
+def store_service_template(core, service_template_path,
+                           service_template_name):
+    core.create_service_template(
+        service_template_path,
+        service_template_dir=os.path.dirname(service_template_path),
+        service_template_name=service_template_name)
+    return service_template_name
+
+
+def create_service(core, service_template_name, inputs):
+    service_template = core.model_storage.service_template.get_by_name(
+        service_template_name)
+    core.create_service(service_template.id, inputs)
+
+
+def install_plugins(sources_dir, plugins_to_install, plugin_manager):
+    prepared_plugins = _prepare_plugins_for_installation(
+        sources_dir, plugins_to_install)
+    for plugin_to_install in prepared_plugins:
+        plugin_path = os.path.join(sources_dir, plugin_to_install)
+        plugin_manager.validate_plugin(plugin_path)
+        plugin_manager.install(plugin_path)
+
+
+def log_unused_plugins(logger, sources_dir, installed_plugins):
+    for file_ in os.listdir(sources_dir):
+        if file_ not in installed_plugins:
+            if file_.endswith(WAGON_EXTENSION):
+                logger.debug('Unused plugin {plugin} in the csar '
+                             'plugins directory'.format(plugin=file_))
+            else:
+                logger.debug('Non-plugin file {file} in the csar plugins '
+                             'directory'.format(file=file_))
+
+
+def cleanup_files(files_to_remove):
+    for path in files_to_remove:
+        _silent_remove(path)
+
+
+def _prepare_plugins_for_installation(sources_dir, plugins_to_install):
+    plugins = set(os.listdir(sources_dir))
+    plugins_to_install = set(plugins_to_install)
+    missing_plugins = plugins_to_install - plugins
+
+    if missing_plugins:
+        raise MissingPluginsException('Requested plugins {0} is not in the'
+                                      ' csar `plugins` directory'
+                                      .format(', '.join(missing_plugins)))
+    return plugins_to_install
+
+
+def _silent_remove(path):
+    try:
+        if os.path.isfile(path):
+            os.remove(path)
+        elif os.path.isdir(path):
+            shutil.rmtree(path)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise


### PR DESCRIPTION
The `create` operation does the following things:
    
1. creates an ARIA working directory for the tenant, if one does not exist.
    
2. installs all the plugins specified in the ARIA-blueprint
    
3. stores the TOSCA service template
    
4. creates a service from the service template
