### PR TITLE
CFY-7400 Exceptions should inherit from Exception not BaseException

### DIFF
--- a/aria_plugin/exceptions.py
+++ b/aria_plugin/exceptions.py
@@ -20,7 +20,7 @@ class MissingPluginsException(NonRecoverableError):
     pass
 
 
-class PluginsAlreadyExistException(BaseException):
+class PluginsAlreadyExistException(Exception):
     pass
 
 


### PR DESCRIPTION
BaseException should only be used for special exceptions that need to
bypass normal exception catching